### PR TITLE
feat: display Spotify user profile (name and avatar) in Navbar

### DIFF
--- a/sonora/src/components/Navbar.tsx
+++ b/sonora/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { signIn, signOut, useSession } from "next-auth/react";
+import Image from "next/image";
 
 export default function Navbar() {
   const { data: session } = useSession();
@@ -8,15 +9,36 @@ export default function Navbar() {
   return (
     <nav className="p-4 bg-gray-900 text-white flex justify-between items-center">
       <h1 className="font-bold text-xl">Sonora</h1>
+
       {session ? (
         <div className="flex items-center gap-4">
-          <span>Hello, {session.user?.name}</span>
-          <button onClick={() => signOut()} className="px-4 py-2 bg-red-600 rounded-lg">
+          {session.user?.image ? (
+            <Image
+              src={session.user.image}
+              alt="User Avatar"
+              width={32}
+              height={32}
+              className="rounded-full"
+            />
+          ) : (
+            <div className="w-8 h-8 rounded-full bg-gray-600 flex items-center justify-center">
+              {session.user?.name?.[0] ?? "?"}
+            </div>
+          )}
+
+          <span>{session.user?.name}</span>
+          <button
+            onClick={() => signOut()}
+            className="px-4 py-2 bg-red-600 rounded-lg"
+          >
             Logout
           </button>
         </div>
       ) : (
-        <button onClick={() => signIn("spotify")} className="px-4 py-2 bg-green-600 rounded-lg">
+        <button
+          onClick={() => signIn("spotify")}
+          className="px-4 py-2 bg-green-600 rounded-lg"
+        >
           Login with Spotify
         </button>
       )}


### PR DESCRIPTION
## Description
This pull request enhances the Navbar by displaying the authenticated Spotify user's profile.

- Added user name to the Navbar
- Displayed user avatar if available
- Fallback avatar with the first letter of the user's name when no image is provided
- Maintained login/logout functionality with Spotify authentication

## Motivation
Improve user experience by showing who is logged in and making the UI feel more personalized.

